### PR TITLE
fix: static files served at relative path

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,11 @@ function middleware (config) {
 
   // render index page
   router.get('/', (req, res) => {
+    // Enforce trailing slash to ensure that static files are served from the correct URL
+    if (!req.originalUrl.endsWith('/')) {
+      return res.redirect(req.originalUrl + '/')
+    }
+
     absoluteUrl.attach(req)
 
     // Create an absolute URL if a relative URL is provided


### PR DESCRIPTION
Depending on if the page was accessed through `/spex/` or `/spex`, static files would get loaded properly or not. Using an absolute URI should fix the issue.

Assuming `${iri}` always contains what we need. Can you confirm that @bergos ?

Should fix https://github.com/zazuko/issues-private/issues/73